### PR TITLE
Bug 869381 - [Build] To overwirte vold.fstab for Supporting Internal/External Storage

### DIFF
--- a/full_leo.mk
+++ b/full_leo.mk
@@ -3,6 +3,7 @@ $(call inherit-product, device/qcom/common/common.mk)
 PRODUCT_COPY_FILES := \
   device/qcom/leo/touchscreen.idc:system/usr/idc/touch_mcs8000.idc \
   device/qcom/leo/media_profiles.xml:system/etc/media_profiles.xml \
+  device/qcom/leo/vold.fstab:system/etc/vold.fstab \
   device/qcom/msm7627a/wpa_supplicant.conf:system/etc/wifi/wpa_supplicant.conf
 
 $(call inherit-product-if-exists, vendor/qcom/leo/leo-vendor-blobs.mk)

--- a/vold.fstab
+++ b/vold.fstab
@@ -1,0 +1,30 @@
+# Copyright (c) 2011, The Linux Foundation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+#       copyright notice, this list of conditions and the following
+#       disclaimer in the documentation and/or other materials provided
+#       with the distribution.
+#     * Neither the name of The Linux Foundation nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#dev_mount sdcard /mnt/sdcard auto /devices/platform/msm_sdcc.1/mmc_host
+dev_mount sdcard /mnt/sdcard auto /devices/platform/msm_sdcc.3/mmc_host
+dev_mount extsdcard /mnt/extsdcard auto /devices/platform/msm_sdcc.1/mmc_host


### PR DESCRIPTION
In order to support internal/external storage in leo device, we need to overwrite the vold.fstab for two volume name and corresponding mount path.
