### PR TITLE
Bug 880726 - [Leo] oncallschanged not triggered for second call on lates...

### DIFF
--- a/full_leo.mk
+++ b/full_leo.mk
@@ -18,6 +18,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
   ro.fm.analogpath.supported=true \
   ro.moz.omx.hw.max_width=640 \
   ro.moz.omx.hw.max_height=480 \
+  ro.moz.ril.extra_int_2nd_call=true \
 
 ENABLE_LIBRECOVERY := true
 # Discard inherited values and use our own instead.


### PR DESCRIPTION
Bug 880726 - [Leo] oncallschanged not triggered for second call on latest b2g18

Adding a quirk ro.moz.ril.extra_int_2nd_call on leo.
